### PR TITLE
Added three additional checkstyle status checks

### DIFF
--- a/checkstyle_checks.xml
+++ b/checkstyle_checks.xml
@@ -3,6 +3,32 @@
           "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
           "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
+<module name="LineLength">
+    <property name="fileExtensions" value="java"/>
+    <property name="max" value="100"/>
+    <property name="ignorePattern"
+             value="^package.*|^import.*|href\s*=\s*&quot;[^&quot;]*&quot;|http://|https://|ftp://"/>
+  </module>
+
+<module name="GenericWhitespace">
+      <message key="ws.followed"
+             value="GenericWhitespace ''{0}'' is followed by whitespace."/>
+      <message key="ws.preceded"
+             value="GenericWhitespace ''{0}'' is preceded with whitespace."/>
+      <message key="ws.illegalFollow"
+             value="GenericWhitespace ''{0}'' should followed by whitespace."/>
+      <message key="ws.notPreceded"
+             value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
+    </module>
+    <module name="Indentation">
+      <property name="basicOffset" value="2"/>
+      <property name="braceAdjustment" value="2"/>
+      <property name="caseIndent" value="2"/>
+      <property name="throwsIndent" value="4"/>
+      <property name="lineWrappingIndentation" value="4"/>
+      <property name="arrayInitIndent" value="2"/>
+    </module>
+
 <module name="Checker">
   <module name="SuppressWarningsFilter"/>
 


### PR DESCRIPTION
Added three check stylestatus check rules to the checkstyle_checks.xml file.  The first status check added is LineLength which simply checks for long lines that can make things more difficult to read, it is currently set to a max of 100 characters long but this can be changed if that is too small I just used the value that was in the checkstyle file provided to us.  The second status check added is GenericWhitespace which checks to make sure that the whitespace around Generic tokens (angle brackets) "<" and ">" are formatted correctly and follow the typical convention.  The third status check added is Indentation to check that the indentation of the java code we write is the correct format and standardized between whoever is writing code.